### PR TITLE
feat: gh-send --all option

### DIFF
--- a/.changeset/quiet-toes-push.md
+++ b/.changeset/quiet-toes-push.md
@@ -1,0 +1,5 @@
+---
+"gh-issue": minor
+---
+
+added --all option

--- a/.changeset/quiet-toes-push.md
+++ b/.changeset/quiet-toes-push.md
@@ -2,4 +2,4 @@
 "gh-issue": minor
 ---
 
-added --all option
+Add the `--all` option

--- a/src/action/send.ts
+++ b/src/action/send.ts
@@ -28,7 +28,7 @@ function createIssueWithGh(issue: { title: string; body: string }) {
 
 export async function sendIssueAction(options: { all?: boolean } = {}) {
   const isAll = options.all || process.env.npm_config_all === "true";
-  const { checkResultReturn, checkResultVoid, createNg } = resultUtility;
+  const { checkResultReturn, checkResultVoid, createNg, createOk } = resultUtility;
   const draftFilesResult = await findDraftIssues();
 
   if (draftFilesResult.isErr) {

--- a/src/action/send.ts
+++ b/src/action/send.ts
@@ -41,24 +41,13 @@ export async function sendIssueAction(options: { all?: boolean } = {}) {
     process.exit(1);
   }
 
-  let draftsToSend: string[];
+  const selectedIssues = isAll
+    ? createOk(draftFilesResult.value)
+    : await selectDraftIssues(draftFilesResult.value);
 
-  if (isAll) {
-    draftsToSend = draftFilesResult.value;
-  } else {
-    const selectedDrafts = await selectDraftIssues(draftFilesResult.value);
-
-    if (selectedDrafts.isErr) {
-      console.error(`Error: ${selectedDrafts.err.message}`);
-      process.exit(1);
-    }
-
-    if (selectedDrafts.value.length === 0) {
-      console.error("No issue drafts selected.");
-      process.exit(1);
-    }
-
-    draftsToSend = selectedDrafts.value;
+  if (selectedIssues.isErr) {
+    console.error(`Error: ${selectedIssues.err.message}`);
+    process.exit(1);
   }
 
   const authResult = checkResultVoid({
@@ -97,7 +86,7 @@ export async function sendIssueAction(options: { all?: boolean } = {}) {
 
   spin.start("Sending issue drafts...");
 
-  for (const selectedDraft of selectedIssues) {
+  for (const selectedDraft of selectedIssues.value) {
     spin.message(`Sending ${selectedDraft}...`);
 
     const issue = parseDraftIssue(selectedDraft);

--- a/src/action/send.ts
+++ b/src/action/send.ts
@@ -26,7 +26,8 @@ function createIssueWithGh(issue: { title: string; body: string }) {
   return runGh(["issue", "create", "--title", issue.title, "--body", issue.body]);
 }
 
-export async function sendIssueAction() {
+export async function sendIssueAction(options: { all?: boolean } = {}) {
+  const isAll = options.all || process.env.npm_config_all === "true";
   const { checkResultReturn, checkResultVoid, createNg } = resultUtility;
   const draftFilesResult = await findDraftIssues();
 
@@ -40,16 +41,24 @@ export async function sendIssueAction() {
     process.exit(1);
   }
 
-  const selectedDrafts = await selectDraftIssues(draftFilesResult.value);
+  let draftsToSend: string[];
 
-  if (selectedDrafts.isErr) {
-    console.error(`Error: ${selectedDrafts.err.message}`);
-    process.exit(1);
-  }
+  if (isAll) {
+    draftsToSend = draftFilesResult.value;
+  } else {
+    const selectedDrafts = await selectDraftIssues(draftFilesResult.value);
 
-  if (selectedDrafts.value.length === 0) {
-    console.error("No issue drafts selected.");
-    process.exit(1);
+    if (selectedDrafts.isErr) {
+      console.error(`Error: ${selectedDrafts.err.message}`);
+      process.exit(1);
+    }
+
+    if (selectedDrafts.value.length === 0) {
+      console.error("No issue drafts selected.");
+      process.exit(1);
+    }
+
+    draftsToSend = selectedDrafts.value;
   }
 
   const authResult = checkResultVoid({
@@ -88,7 +97,7 @@ export async function sendIssueAction() {
 
   spin.start("Sending issue drafts...");
 
-  for (const selectedDraft of selectedDrafts.value) {
+  for (const selectedDraft of draftsToSend) {
     spin.message(`Sending ${selectedDraft}...`);
 
     const issue = parseDraftIssue(selectedDraft);

--- a/src/action/send.ts
+++ b/src/action/send.ts
@@ -97,7 +97,7 @@ export async function sendIssueAction(options: { all?: boolean } = {}) {
 
   spin.start("Sending issue drafts...");
 
-  for (const selectedDraft of draftsToSend) {
+  for (const selectedDraft of selectedIssues) {
     spin.message(`Sending ${selectedDraft}...`);
 
     const issue = parseDraftIssue(selectedDraft);

--- a/src/command/core.ts
+++ b/src/command/core.ts
@@ -25,7 +25,11 @@ export function createCommander() {
     .action(initAction);
 
   program.command("create").description("Create an issue template").action(createIssueAction);
-  program.command("send").description("Send an issue draft to GitHub").action(sendIssueAction);
+  program
+    .command("send")
+    .description("Send an issue draft to GitHub")
+    .option("--all", "Send all issue drafts without selection prompt")
+    .action((options) => sendIssueAction(options));
 
   return program;
 }


### PR DESCRIPTION
# Pull Request

## Summary

下記コマンドが、--all オプションを受け付けるようにしました。

```
npm run gh-send
```

## How to test

npm run gh-send コマンドにて従来通りの選択式送信が可能であること
npm run gh-send --all コマンドにて新たに未送信Issueの一括送信が可能であること

上記2点を確認しました。

## Checklist

- [x] I have added/updated tests where applicable
- [x] I have added/updated documentation where applicable
- [x] The PR references the related Issue (see "Related Issue" section)
