### PR TITLE
[codex] add textarea editor options to create command

### DIFF
--- a/.changeset/big-hats-tan.md
+++ b/.changeset/big-hats-tan.md
@@ -1,0 +1,5 @@
+---
+"gh-issue": minor
+---
+
+Add editing options for the text area

--- a/src/action/create.ts
+++ b/src/action/create.ts
@@ -9,13 +9,14 @@ import { textPrompts } from "../command/common";
 import { createContents, IssueContents } from "../helper/create-contents";
 import { writeIssueMarkdown } from "../helper/write-issue-markdown";
 import { log } from "@clack/prompts";
+import type { TextareaCreateOptions } from "../helper/textarea-options";
 
 export interface SelectMaterial {
   name: string;
   fileName: string;
 }
 
-export async function createIssueAction() {
+export async function createIssueAction(options: TextareaCreateOptions = {}) {
   const { checkResultReturn, createNg } = resultUtility;
   const { optionConversion } = optionUtility;
   const ghIssueDir = join(process.cwd(), ".gh-issue");
@@ -89,7 +90,7 @@ export async function createIssueAction() {
   });
 
   for (const tmp of foundTemplate.value.contents.body) {
-    const contentResult = await createContents(tmp);
+    const contentResult = await createContents(tmp, options);
 
     if (contentResult.isErr) {
       log.error(`Error: ${contentResult.err.message}`);

--- a/src/command/core.ts
+++ b/src/command/core.ts
@@ -24,7 +24,12 @@ export function createCommander() {
     .description("Create bug report and feature request issue templates")
     .action(initAction);
 
-  program.command("create").description("Create an issue template").action(createIssueAction);
+  program
+    .command("create")
+    .description("Create an issue template")
+    .option("--vim", "Use Vim editor for textarea")
+    .option("--no-vim", "Use default editor for textarea")
+    .action((options) => createIssueAction(options));
   program
     .command("send")
     .description("Send an issue draft to GitHub")

--- a/src/helper/create-contents.ts
+++ b/src/helper/create-contents.ts
@@ -11,6 +11,11 @@ import {
 import { parseCheckboxesValue } from "./checkboxes-parser";
 import { log } from "@clack/prompts";
 import { editTextareaWithVim } from "./textarea-editor";
+import {
+  resolveTextareaEditorMode,
+  type TextareaCreateOptions,
+  type TextareaEditorMode,
+} from "./textarea-options";
 
 export interface IssueContents {
   title: string;
@@ -19,6 +24,7 @@ export interface IssueContents {
 
 export async function createContents(
   tmpBody: IssueFormElement,
+  options?: TextareaCreateOptions,
 ): Promise<Result<Option<IssueContents>, Error>> {
   const { createOk, createNg } = resultUtility;
   const { createNone, createSome } = optionUtility;
@@ -60,47 +66,78 @@ export async function createContents(
         `${bold(blue(tmpBody.attributes.label))} ${tmpBody.validations?.required ? red("*") : ""}\n\n`,
       );
       log.message(blue(tmpBody.attributes.description || "No description") + "\n");
+      const required = tmpBody.validations?.required === true;
+      const presetEditorMode = resolveTextareaEditorMode(options);
+      let inputMode: TextareaEditorMode | "skip";
 
-      const inputModeOptions: PromptOption<"vim" | "direct" | "skip">[] = [
-        {
-          title: "Open in vim",
-          value: "vim",
-          hint: "Edit in a temporary hidden file",
-          selected: true,
-        },
-        {
-          title: "Enter directly",
-          value: "direct",
-          hint: "Use the current multiline prompt",
-        },
-      ];
+      if (presetEditorMode.isNone) {
+        const inputModeOptions: PromptOption<"vim" | "direct" | "skip">[] = [
+          {
+            title: "Open in vim",
+            value: "vim",
+            hint: "Edit in a temporary hidden file",
+            selected: true,
+          },
+          {
+            title: "Enter directly",
+            value: "direct",
+            hint: "Use the current multiline prompt",
+          },
+        ];
 
-      if (!tmpBody.validations?.required) {
-        inputModeOptions.push({
-          title: "Do not enter content",
-          value: "skip",
-          hint: "Store an empty string for this field",
+        if (!required) {
+          inputModeOptions.push({
+            title: "Do not enter content",
+            value: "skip",
+            hint: "Store an empty string for this field",
+          });
+        }
+
+        const inputModeResult = await selectPrompts<"vim" | "direct" | "skip">({
+          message: `${tmpBody.attributes.label}\nChoose how to enter the textarea content`,
+          options: inputModeOptions,
         });
-      }
 
-      const inputModeResult = await selectPrompts<"vim" | "direct" | "skip">({
-        message: "Choose how to enter the textarea content",
-        options: inputModeOptions,
-      });
+        if (inputModeResult.isErr) {
+          return createNg(inputModeResult.err);
+        }
 
-      if (inputModeResult.isErr) {
-        return createNg(inputModeResult.err);
+        inputMode = inputModeResult.value;
+      } else if (required) {
+        inputMode = presetEditorMode.value;
+      } else {
+        const shouldEditResult = await selectPrompts<"edit" | "skip">({
+          message: `${tmpBody.attributes.label}\nChoose whether to edit this textarea content`,
+          options: [
+            {
+              title: presetEditorMode.value === "vim" ? "Edit in vim" : "Enter directly",
+              value: "edit",
+              selected: true,
+            },
+            {
+              title: "Do not enter content",
+              value: "skip",
+              hint: "Store an empty string for this field",
+            },
+          ],
+        });
+
+        if (shouldEditResult.isErr) {
+          return createNg(shouldEditResult.err);
+        }
+
+        inputMode = shouldEditResult.value === "skip" ? "skip" : presetEditorMode.value;
       }
 
       const textareaResult =
-        inputModeResult.value === "skip"
+        inputMode === "skip"
           ? resultUtility.createOk("")
-          : inputModeResult.value === "vim"
+          : inputMode === "vim"
             ? await editTextareaWithVim({
                 initialValue: tmpBody.attributes.value,
                 title: tmpBody.attributes.label,
                 description: tmpBody.attributes.description,
-                allowEmpty: tmpBody.validations?.required === true,
+                allowEmpty: required,
               })
             : await multilineTextPrompts({
                 message: tmpBody.attributes.label,
@@ -111,7 +148,7 @@ export async function createContents(
         return createNg(textareaResult.err);
       }
 
-      if (tmpBody.validations?.required && (textareaResult.value as string).trim().length === 0) {
+      if (required && (textareaResult.value as string).trim().length === 0) {
         return createNg(new Error("This field is required"));
       }
 

--- a/src/helper/textarea-options.ts
+++ b/src/helper/textarea-options.ts
@@ -1,0 +1,24 @@
+import { Option, optionUtility } from "ts-shared";
+
+export type TextareaEditorMode = "vim" | "direct";
+
+export interface TextareaCreateOptions {
+  vim?: boolean;
+  noVim?: boolean;
+}
+
+export function resolveTextareaEditorMode(
+  options?: TextareaCreateOptions,
+): Option<TextareaEditorMode> {
+  const { createNone, createSome } = optionUtility;
+
+  if (options?.vim === true) {
+    return createSome("vim");
+  }
+
+  if (options?.vim === false || options?.noVim === true) {
+    return createSome("direct");
+  }
+
+  return createNone();
+}


### PR DESCRIPTION
## Summary

- add create-command editor options to preselect textarea input mode
- skip the textarea mode chooser when the editor is already determined for required fields
- keep optional textarea fields editable or skippable even when the editor is preset

## Why

When users already know whether they want to use vim or direct input, asking the same textarea mode question repeatedly adds friction to issue drafting.

## What Changed

- added `--vim` and `--no-vim` handling to the create command flow
- passed textarea editor preferences from the create action into content generation
- introduced a textarea option resolver based on `Option`
- updated textarea prompting logic to:
  - keep the existing full chooser when no option is provided
  - skip the chooser for required fields when the editor is already fixed
  - ask only whether to edit or skip for optional fields when the editor is already fixed

## User Impact

- users can lock textarea entry to vim or direct input from the CLI
- required textareas move faster when the editor mode is already known
- optional textareas still allow skipping content without reopening the mode chooser

## Root Cause

The textarea flow always prompted for input mode, even when the create command already had enough information to determine the editor choice.

## Validation

- `pnpm build`

## Issue

- none
