### PR TITLE
[codex] Add assignee support to issue drafts

### DIFF
--- a/.changeset/open-lies-crash.md
+++ b/.changeset/open-lies-crash.md
@@ -1,0 +1,5 @@
+---
+"gh-issue": minor
+---
+
+We have enabled assignment.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ A command line tool for setting up GitHub Issue templates and drafting issues fr
 - Node.js `>= 20`
 - GitHub CLI `gh` for the `send` command
 
+## Authentication
+
+Authenticate GitHub CLI before using `gh-issue`:
+
+```sh
+gh auth login
+```
+
+This is required because `gh-issue` uses `gh` to inspect repositories and create issues.
+
 ## Installation
 
 ### Global installation
@@ -159,12 +169,6 @@ When Vim is used:
 
 Create GitHub Issues from Markdown drafts stored in `.gh-issue/`.
 
-Before using this command, authenticate GitHub CLI:
-
-```sh
-gh auth login
-```
-
 This command:
 
 - reads draft files from `.gh-issue/`
@@ -214,10 +218,11 @@ The build fails when running the release workflow.
 
 ## Typical workflow
 
-1. Run `gh-issue init`
-2. Run `gh-issue create`
-3. Review the draft in `.gh-issue/`
-4. Run `gh-issue send`
+1. Run `gh auth login`
+2. Run `gh-issue init`
+3. Run `gh-issue create`
+4. Review the draft in `.gh-issue/`
+5. Run `gh-issue send`
 
 ## Notes
 

--- a/src/action/create.ts
+++ b/src/action/create.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { optionUtility, resultUtility } from "ts-shared";
@@ -5,7 +6,7 @@ import { findTemplates } from "../helper/find-template";
 import { ymlParse } from "../helper/yml";
 import { selectTemplate } from "../command/create";
 import { bold, green } from "picocolors";
-import { textPrompts } from "../command/common";
+import { multiselectPrompts, textPrompts } from "../command/common";
 import { createContents, IssueContents } from "../helper/create-contents";
 import { writeIssueMarkdown } from "../helper/write-issue-markdown";
 import { log } from "@clack/prompts";
@@ -14,6 +15,41 @@ import type { TextareaCreateOptions } from "../helper/textarea-options";
 export interface SelectMaterial {
   name: string;
   fileName: string;
+}
+
+function getAssignableUsers() {
+  const { checkResultReturn, createNg, createOk } = resultUtility;
+
+  const repo = checkResultReturn({
+    fn: () =>
+      execFileSync("gh", ["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      }).trim(),
+    err: (e) => createNg(new Error(`error:${e}`)),
+  });
+
+  if (repo.isErr) {
+    return repo;
+  }
+
+  if (repo.value.length === 0) {
+    return createOk([]);
+  }
+
+  const list = checkResultReturn({
+    fn: () =>
+      execFileSync("gh", ["api", `repos/${repo.value}/assignees`, "--jq", ".[].login"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      })
+        .trim()
+        .split("\n")
+        .filter(Boolean),
+    err: (e) => createNg(`error: ${e}`),
+  });
+
+  return list;
 }
 
 export async function createIssueAction(options: TextareaCreateOptions = {}) {
@@ -99,6 +135,35 @@ export async function createIssueAction(options: TextareaCreateOptions = {}) {
 
     if (contentResult.value.isSome) {
       issueContents.push(contentResult.value.value);
+    }
+  }
+
+  const assignees = getAssignableUsers();
+
+  if (assignees.isErr) {
+    throw assignees.err;
+  }
+
+  if (assignees.value.length > 0) {
+    const assigneeResult = await multiselectPrompts<string>({
+      message: "Select assignees",
+      required: false,
+      options: assignees.value.map((assignee) => ({
+        title: assignee,
+        value: assignee,
+      })),
+    });
+
+    if (assigneeResult.isErr) {
+      log.error(`Error: ${assigneeResult.err.message}`);
+      process.exit(1);
+    }
+
+    if (assigneeResult.value.length > 0) {
+      issueContents.push({
+        title: "assign",
+        contents: assigneeResult.value.join(","),
+      });
     }
   }
 

--- a/src/action/send.ts
+++ b/src/action/send.ts
@@ -22,8 +22,14 @@ function resolveRepository() {
   return runGh(["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]);
 }
 
-function createIssueWithGh(issue: { title: string; body: string }) {
-  return runGh(["issue", "create", "--title", issue.title, "--body", issue.body]);
+function createIssueWithGh(issue: { title: string; body: string; assignees?: string[] }) {
+  const args = ["issue", "create", "--title", issue.title, "--body", issue.body];
+
+  if (issue.assignees && issue.assignees.length > 0) {
+    args.push("--assignee", issue.assignees.join(","));
+  }
+
+  return runGh(args);
 }
 
 export async function sendIssueAction(options: { all?: boolean } = {}) {

--- a/src/command/common.ts
+++ b/src/command/common.ts
@@ -148,11 +148,13 @@ export async function selectPrompts<T extends PromptValue>({
 export async function multiselectPrompts<T extends PromptValue>({
   message,
   options,
+  required,
   cancelMessage = "Selection canceled.",
   errorMessage = "Failed to select options",
 }: {
   message: string;
   options: PromptOption<T>[];
+  required?: boolean;
   cancelMessage?: string;
   errorMessage?: string;
 }): Promise<Result<T[], Error>> {
@@ -164,6 +166,7 @@ export async function multiselectPrompts<T extends PromptValue>({
     fn: async () =>
       await multiselect({
         message,
+        required,
         initialValues,
         options: options.map((option) => toClackOption(option)) as never,
       }),

--- a/src/helper/draft-issue.ts
+++ b/src/helper/draft-issue.ts
@@ -10,6 +10,7 @@ export interface DraftIssue {
   filePath: string;
   title: string;
   body: string;
+  assignees?: string[];
 }
 
 export async function findDraftIssues(cwd = process.cwd()): Promise<Result<string[], Error>> {
@@ -43,6 +44,7 @@ export function parseDraftIssue(filePath: string, cwd = process.cwd()): DraftIss
 
   const [, frontMatter, markdownBody] = frontMatterMatch;
   const titleMatch = frontMatter.match(/^title:\s*(.+)$/m);
+  const assignMatch = frontMatter.match(/^assign:\s*(.+)$/m);
 
   if (!titleMatch) {
     throw new Error(`Missing title in front matter: ${filePath}`);
@@ -52,5 +54,9 @@ export function parseDraftIssue(filePath: string, cwd = process.cwd()): DraftIss
     filePath,
     title: titleMatch[1].trim(),
     body: markdownBody.trim(),
+    assignees: assignMatch?.[1]
+      ?.split(",")
+      .map((assignee) => assignee.trim())
+      .filter(Boolean),
   };
 }

--- a/src/helper/write-issue-markdown.ts
+++ b/src/helper/write-issue-markdown.ts
@@ -5,6 +5,7 @@ import { optionUtility, Result, resultUtility } from "ts-shared";
 import { IssueContents } from "./create-contents";
 
 const TITLE_KEY = "title";
+const ASSIGN_KEY = "assign";
 const fileNameAdjectives = [
   "ancient",
   "blue",
@@ -33,13 +34,22 @@ const fileNameNouns = [
 export function createIssueMarkdown(issueContents: IssueContents[]): Result<string, Error> {
   const { createNg, createOk } = resultUtility;
   const titleContent = issueContents.find((content) => content.title === TITLE_KEY);
+  const assignContent = issueContents.find((content) => content.title === ASSIGN_KEY);
 
   if (!titleContent) {
     return createNg(new Error("Title content is required"));
   }
 
-  const bodyContents = issueContents.filter((content) => content.title !== TITLE_KEY);
-  const markdownLines = [`---`, `title: ${titleContent.contents}`, `---`, ``];
+  const bodyContents = issueContents.filter(
+    (content) => content.title !== TITLE_KEY && content.title !== ASSIGN_KEY,
+  );
+  const markdownLines = [`---`, `title: ${titleContent.contents}`];
+
+  if (assignContent && assignContent.contents.trim().length > 0) {
+    markdownLines.push(`assign: ${assignContent.contents}`);
+  }
+
+  markdownLines.push(`---`, ``);
 
   for (const content of bodyContents) {
     markdownLines.push(`## ${content.title}`, ``, content.contents, ``);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,11 +1,13 @@
 import { existsSync, writeFileSync } from "node:fs";
-import { copyFile, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { basename } from "node:path";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { beforeAll, afterAll, describe, expect, it, vi } from "vitest";
 
+import { parseDraftIssue } from "../src/helper/draft-issue";
 import { editTextareaWithVim } from "../src/helper/textarea-editor";
+import { createIssueMarkdown } from "../src/helper/write-issue-markdown";
 import { main } from "../src/index";
 import { createIssueTemplate, createIssueTemplateYaml, initIssueTemplates } from "../src/templates";
 
@@ -172,5 +174,68 @@ describe("editTextareaWithVim", () => {
     expect(result.value).toBe("Edited in vim");
     expect(basename(openedEditorPath)).toMatch(/^\.gh-issue-.*\.md$/);
     expect(existsSync(openedEditorPath)).toBe(false);
+  });
+});
+
+describe("createIssueMarkdown", () => {
+  it("writes assign after title in front matter", () => {
+    const result = createIssueMarkdown([
+      { title: "title", contents: "Issue title" },
+      { title: "assign", contents: "octocat,hubot" },
+      { title: "Details", contents: "Body text" },
+    ]);
+
+    expect(result.isOk).toBe(true);
+
+    if (result.isErr) {
+      throw result.err;
+    }
+
+    expect(result.value).toContain("---\ntitle: Issue title\nassign: octocat,hubot\n---");
+    expect(result.value).toContain("## Details\n\nBody text");
+  });
+
+  it("omits assign when no assignee is selected", () => {
+    const result = createIssueMarkdown([
+      { title: "title", contents: "Issue title" },
+      { title: "Details", contents: "Body text" },
+    ]);
+
+    expect(result.isOk).toBe(true);
+
+    if (result.isErr) {
+      throw result.err;
+    }
+
+    expect(result.value).toContain("---\ntitle: Issue title\n---");
+    expect(result.value).not.toContain("assign:");
+  });
+});
+
+describe("parseDraftIssue", () => {
+  it("reads assign from front matter when present", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "gh-issue-"));
+    const filePath = join(cwd, ".gh-issue", "draft.md");
+
+    await mkdir(join(cwd, ".gh-issue"), { recursive: true });
+    await writeFile(
+      filePath,
+      [
+        "---",
+        "title: Issue title",
+        "assign: octocat, hubot",
+        "---",
+        "",
+        "## Details",
+        "",
+        "Body",
+      ].join("\n"),
+    );
+
+    const issue = parseDraftIssue(".gh-issue/draft.md", cwd);
+
+    expect(issue.title).toBe("Issue title");
+    expect(issue.assignees).toEqual(["octocat", "hubot"]);
+    expect(issue.body).toBe("## Details\n\nBody");
   });
 });


### PR DESCRIPTION
## Summary
- add assignee selection to gh-issue create, including optional multi-select behavior
- persist assignees in draft front matter and pass them through gh-issue send
- document gh auth login earlier in the README and remove the duplicated note from send

## Why
This adds assignment support to the local draft workflow while keeping assignees optional, so users can create and send drafts without being forced to choose one.

## Validation
- pnpm test
- pre-commit hooks: build, lint, format
